### PR TITLE
Rename `info.name` to `info.logger`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # CHANGELOG
 
 ## [Unreleased]
+### Changed
+- Renamed `options.name` --> `options.logger`
+- `err` includes `err.name` and `err.stack`
+
+
+## [0.9.1] -- 2018-12-10
 - Added repo badging (npm, snyk, david-dm)
 
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ const logger = createLogger({
 });
 const options = { 
     service: 'test-service', 
-    name: 'Winston-JSON-Formatter', 
+    logger: 'Winston-JSON-Formatter',
     version: '1.0.0', 
     typeFormat: 'json'
 };
@@ -30,12 +30,17 @@ const options = {
 // set winston logger format and print logs.
 logger.format = configuredFormatter(options);
 
+// Availale log levels
 logger.error('message');
 logger.warn('message');
 logger.info('message');
 logger.verbose('message');
 logger.debug('message');
 logger.silly('message');
+
+// Error Objects can be logged directly
+err = new Error('Heroic BSoD')
+logger.error(err)
 ```
 
 ## Output
@@ -70,12 +75,18 @@ logger.silly('message');
 ![console log style](docs/console-log-example.png)
 
 ## Configuration
+ENV
+- `NODE_ENV=dev` || `NODE_ENV=development` => `options.typeFormat=console`
+- Otherwise, `options.typeFormat=json` (default)
 
-- ENV
-  * `NODE_ENV=dev` || `NODE_ENV=development` => `options.typeFormat=console`
-  * Otherwise, `options.typeFormat=json` (default)
-- options
-  * `options.typeFormat` (Default: json) [Enum: console, json]
+| Option               | Default                       | Type                    |
+| -------------------- | ----------------------------- | ----------------------- |
+| `options.typeFormat` | Default: 'json'               | Enum: 'console', 'json' |
+| `options.hostname`   | Default: `os.hostname()`      | String                  |
+| `options.logger`     | Default: 'application-logger' | String                  |
+| `options.node_env`   | Default: `ENV NODE_ENV`       | String                  |
+| `options.service`    |                               | String                  |
+| `options.version`    |                               | String                  |
 
 ## Test
 ```bash

--- a/src/index.js
+++ b/src/index.js
@@ -11,8 +11,8 @@ const addMetaFormat = format((info, opts) => {
     const options = _.defaults(
         opts,
         {
-            name: 'application-logger',
             hostname: os.hostname(),
+            logger: 'application-logger',
             node_env: process.env.NODE_ENV,
             service: '',
             version: ''
@@ -44,7 +44,7 @@ const jsonFormat = printf((info) => {
 
     return JSON.stringify({
         service: info.service || '',
-        logger: info.name || 'application-logger',
+        logger: info.logger || 'application-logger',
         hostname: info.hostname || '',
         level: info.level,
         msg: info.message,
@@ -59,8 +59,6 @@ const jsonFormat = printf((info) => {
             event: parseInfo(info),
         },
         err: {
-            err: info.err,
-            message: info.message,
             name: info.name,
             stack: info.stack
         }

--- a/test/format.test.js
+++ b/test/format.test.js
@@ -26,7 +26,7 @@ beforeEach(() => {
 
     options = {
         service: 'test-service',
-        name: 'test-name',
+        logger: 'test-logger',
         version: 'test-version',
     };
 });
@@ -63,7 +63,7 @@ describe('configuredFormatter testing', () => {
                 expect(parsedTestMsg.level).toEqual('info');
                 expect(parsedTestMsg.msg).toEqual('message');
                 expect(parsedTestMsg.service).toEqual(options.service);
-                expect(parsedTestMsg.logger).toEqual(options.name);
+                expect(parsedTestMsg.logger).toEqual(options.logger);
                 expect(parsedTestMsg.meta.service.version).toEqual(options.version);
                 expect(parsedTestMsg.meta.event.foo).toEqual('bar');
             });


### PR DESCRIPTION
Because `info.name` is used by both the logger name and the error name.

If this PR fixes a bug, you _must_ add test cases representative of the bug.

#### What does this PR do?
`info.name` is used by both Error objects and the logger name.

Previously...
```
options.name = "MyLoggerName"
logger.error('msg')
{logger: "MyLoggerName", err: {}}
```

```
a = new Error('err')
logger.error(a)
{logger: "Error", err: {name: "Error"}}
```

By renaming `option.name` --> `options.logger`, we avoid the collision of Error.name and options.name.

Unfortunately, this is a breaking change, so following semver it'd be `0.9.0` --> `1.0.0`

#### Related JIRA tickets:

#### How should this be manually tested?

#### Background/Context

#### Screenshots (if appropriate):
