### PR TITLE
[SER-281] Log Errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,37 +44,6 @@ err = new Error('Heroic BSoD')
 logger.error(err)
 ```
 
-## Output
-
-### Json logging
-```javascript
-> logger.info('message', {foo: 'bar', baz: 'qux'});
-{
-  "service": "test-service",
-  "logger": "Winston-JSON-Formatter",
-  "hostname": "host",
-  "level": "info",
-  "msg": "message",
-  "meta": {
-    "service": {
-      "version": "1.0.0",
-      "node_env": ""
-    },
-    "logger": {
-      "time": "2018-11-28T02:52:06.700Z"
-    },
-    "event": {
-      "foo": "bar",
-      "baz": "qux"
-    }
-  },
-  "err": {}
-}
-```
-
-### Console logging
-![console log style](docs/console-log-example.png)
-
 ## Configuration
 ENV
 - `NODE_ENV=dev` || `NODE_ENV=development` => `options.typeFormat=console`
@@ -94,4 +63,225 @@ ENV
 yarn install
 yarn test
 yarn test:coverage
+```
+
+## Output
+
+### Json logging
+```javascript
+
+> const err = new Error('error message');
+> const err.code = 'SOME_CODE';
+> // The colon and space here are recommended due to this bug in winston (https://github.com/winstonjs/winston/issues/1634)
+> logger.info('log message: ', err);
+{
+  "service": "test-service",
+  "logger": "Winston-JSON-Formatter",
+  "hostname": "host",
+  "level": "info",
+  "msg": "log message: error message",
+  "meta": {
+    "service": {
+      "version": "1.0.0",
+      "node_env": ""
+    },
+    "logger": {
+      "time": "2018-11-28T02:52:06.700Z"
+    },
+    "event": {
+      "code": "SOME_CODE"
+    }
+  },
+  "err": {
+    // There should be a member `"name": "Error"` here if it were not for winston bug (https://github.com/winstonjs/winston/issues/1635)
+    "stack": "THE_ERROR_STACK"
+  }
+}
+
+> const err = new Error('error message');
+> const err.code = 'SOME_CODE';
+> logger.info(err, {foo: 'bar', baz: 'qux'});
+{
+  "service": "test-service",
+  "logger": "Winston-JSON-Formatter",
+  "hostname": "host",
+  "level": "info",
+  "msg": "message: error message",
+  "meta": {
+    "service": {
+      "version": "1.0.0",
+      "node_env": ""
+    },
+    "logger": {
+      "time": "2018-11-28T02:52:06.700Z"
+    },
+    "event": {
+      "foo": "bar",
+      "baz": "qux",
+      "code": "SOME_CODE"
+    }
+  },
+  "err": {
+    "name": "Error"
+    "stack": "THE_ERROR_STACK"
+  }
+}
+```
+
+### Console logging
+![console log style](docs/console-log-example.png)
+
+
+```sh
+# Generally, the format is:
+
+# timestamp level message
+# stack_if_one_exists
+# {
+#   other: 'members-if-they-exist'
+# }
+
+# > logger.info("log message") ------------------------------------------------------------------ 
+2019-04-12T02:10:11.091Z info log message  
+# ----
+
+
+# > logger.info(new Error("error message")) ------------------------------------------------------------------ 
+2019-04-12T02:10:11.094Z info error message 
+Error: error message
+    at Object.<anonymous> (/Users/houli/docs/gitrepos/amida-tech/winston-json-formatter/experiment.js:38:13)
+    at Module._compile (module.js:653:30)
+    at Object.Module._extensions..js (module.js:664:10)
+    at Module.load (module.js:566:32)
+    at tryModuleLoad (module.js:506:12)
+    at Function.Module._load (module.js:498:3)
+    at Function.Module.runMain (module.js:694:10)
+    at startup (bootstrap_node.js:204:16)
+    at bootstrap_node.js:625:3 
+# ----
+
+
+# > logger.info("message", new Error("error message")) ------------------------------------------------------------------ 
+2019-04-12T02:10:11.095Z info log messageerror message 
+Error: error message
+    at Object.<anonymous> (/Users/houli/docs/gitrepos/amida-tech/winston-json-formatter/experiment.js:41:28)
+    at Module._compile (module.js:653:30)
+    at Object.Module._extensions..js (module.js:664:10)
+    at Module.load (module.js:566:32)
+    at tryModuleLoad (module.js:506:12)
+    at Function.Module._load (module.js:498:3)
+    at Function.Module.runMain (module.js:694:10)
+    at startup (bootstrap_node.js:204:16)
+    at bootstrap_node.js:625:3 
+# ----
+
+
+# > logger.info({a: "a", b: "b"}) ------------------------------------------------------------------ 
+2019-04-12T02:10:11.095Z info 
+{
+  "a": "a",
+  "b": "b"
+}  
+# ----
+
+
+# > logger.info(new Error("error message"), { a: "a", b: "b" } ) ------------------------------------------------------------------ 
+2019-04-12T02:10:11.096Z info error message 
+Error: error message
+    at Object.<anonymous> (/Users/houli/docs/gitrepos/amida-tech/winston-json-formatter/experiment.js:47:13)
+    at Module._compile (module.js:653:30)
+    at Object.Module._extensions..js (module.js:664:10)
+    at Module.load (module.js:566:32)
+    at tryModuleLoad (module.js:506:12)
+    at Function.Module._load (module.js:498:3)
+    at Function.Module.runMain (module.js:694:10)
+    at startup (bootstrap_node.js:204:16)
+    at bootstrap_node.js:625:3 
+{
+  "a": "a",
+  "b": "b"
+}
+# ----
+
+
+# Logging an object that is not an Error that does have a member named stack will confuse the logger. This is unavoidable.
+# > logger.info({ name: "some name", stack: "some stack" }) ------------------------------------------------------------------ 
+2019-04-12T02:10:11.096Z info 
+{
+  "name": "some name",
+  "stack": "some stack"
+} 
+some stack 
+# ----
+
+
+# Logging an object that is not an Error that does have a member named stack will confuse the logger. This is unavoidable.
+# > logger.info("message", { name: "some name", stack: "some stack" }) ------------------------------------------------------------------ 
+2019-04-12T02:10:11.096Z info message 
+some stack 
+# ----
+
+
+# > logger.info("message", { a: "a", b: "b" }) ------------------------------------------------------------------ 
+2019-04-12T02:10:11.096Z info message  
+{
+  "a": "a",
+  "b": "b"
+}
+# ----
+
+
+# > const err = new Error("error message"); err.code = "SOME_CODE"; logger.info("message", new Error("error message")) ------------------------------------------------------------------ 
+2019-04-12T02:10:11.097Z info messageError A 
+Error: Error A
+    at Object.<anonymous> (/Users/houli/docs/gitrepos/amida-tech/winston-json-formatter/experiment.js:58:14)
+    at Module._compile (module.js:653:30)
+    at Object.Module._extensions..js (module.js:664:10)
+    at Module.load (module.js:566:32)
+    at tryModuleLoad (module.js:506:12)
+    at Function.Module._load (module.js:498:3)
+    at Function.Module.runMain (module.js:694:10)
+    at startup (bootstrap_node.js:204:16)
+    at bootstrap_node.js:625:3 
+{
+  "code": "SOME_CODE"
+}
+# ----
+
+
+# > const err = new Error("error message"); err.code = "SOME_CODE"; logger.info(new Error("error message")) ------------------------------------------------------------------ 
+2019-04-12T02:10:11.097Z info Error A 
+Error: Error A
+    at Object.<anonymous> (/Users/houli/docs/gitrepos/amida-tech/winston-json-formatter/experiment.js:58:14)
+    at Module._compile (module.js:653:30)
+    at Object.Module._extensions..js (module.js:664:10)
+    at Module.load (module.js:566:32)
+    at tryModuleLoad (module.js:506:12)
+    at Function.Module._load (module.js:498:3)
+    at Function.Module.runMain (module.js:694:10)
+    at startup (bootstrap_node.js:204:16)
+    at bootstrap_node.js:625:3 
+{
+  "code": "SOME_CODE"
+}
+# ----
+
+
+# > const err = new Error("error message"); err.code = "SOME_CODE"; logger.info(new Error("error message"), { a: "a", b: "b" } ) ------------------------------------------------------------------ 
+2019-04-12T02:10:11.097Z info Error A 
+Error: Error A
+    at Object.<anonymous> (/Users/houli/docs/gitrepos/amida-tech/winston-json-formatter/experiment.js:58:14)
+    at Module._compile (module.js:653:30)
+    at Object.Module._extensions..js (module.js:664:10)
+    at Module.load (module.js:566:32)
+    at tryModuleLoad (module.js:506:12)
+    at Function.Module._load (module.js:498:3)
+    at Function.Module.runMain (module.js:694:10)
+    at startup (bootstrap_node.js:204:16)
+    at bootstrap_node.js:625:3 
+{
+  "a": "a",
+  "b": "b",
+  "code": "SOME_CODE"
+}
 ```

--- a/README.md
+++ b/README.md
@@ -285,3 +285,40 @@ Error: Error A
   "code": "SOME_CODE"
 }
 ```
+
+## Miscellaneous Goodies
+
+This repo also provides a function to check if a particular log level is greater than the currently configured log level.
+
+Example useage:
+
+```js
+// In some service...
+
+// config.js
+module.exports = {
+    logLevel: 'info',
+}
+
+// FancyCustomError.js
+import { initLogLevelGte } from 'winston-json-formatter'
+const config = require('../config/index.js')
+const logLevelGte = initLogLevelGte(config.logLevel)
+
+class FancyCustomError extends Error {
+  constructor(rootErrorThatCouldHaveSecretStuffInIt, message, foo, bar) {
+    super()
+
+    this.message = message
+
+    if (logLevelGte('debug')) {
+        this.rootErrorThatCouldHaveSecretStuffInIt = rootErrorThatCouldHaveSecretStuffInIt
+    }
+  }
+}
+
+// someFile.js
+logger.info(new FancyCustomError(err, 'Error creating user'))
+
+// When the configured log level is 'info', you would see logged only 'Error creating user', but when the configured log level is 'debug', you would see all the guts and glory.
+```

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "lodash": "^4.17.11",
     "os": "^0.1.1",
-    "winston": "^3.1.0"
+    "winston": "^3.2.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.1.5",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,10 @@
     {
       "name": "Ryan Harrison",
       "email": "ryan@amida.com"
+    },
+    {
+      "name": "Aaron Houlihan",
+      "email": "aaron@amida.com"
     }
   ],
   "dependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -22,14 +22,57 @@ const addMetaFormat = format((info, opts) => {
     return _.defaults(info, options);
 });
 
-const consoleFormat = printf(info => util.format(
-    '%s %s %s %s %s',
-    info.timestamp,
-    info.level,
-    (typeof info.message === 'string') ? info.message : `\n${JSON.stringify(info.message, null, 2)}`,
-    (info.stack) ? `\n${info.stack}` : '',
-    (!_.isEmpty(parseInfo(info))) ? `\n${JSON.stringify(parseInfo(info), null, 2)}` : ''
-));
+const consoleFormat = printf((info) => {
+    let message;
+    if (info.message instanceof Error) {
+        // eslint-disable-next-line prefer-destructuring
+        message = info.message.message;
+    } else if (typeof info.message === 'string') {
+        // eslint-disable-next-line prefer-destructuring
+        message = info.message;
+    } else {
+        message = `\n${JSON.stringify(info.message, null, 2)}`;
+    }
+
+    const stack = info.stack || info.message.stack;
+
+    let event;
+    let eventString;
+    if (info.message instanceof Error) {
+        event = parseInfo(info);
+
+        // Unfortunately, in this case...
+        // ```
+        // const err = new Error('error message');
+        // err.code = 'SOME_CODE'
+        // logger.info(err, { a: 'a', b: 'b' })
+        // ```
+        // ...the configured logger members (such as timestamp, service, node_env, etc.)
+        // are members of info (expected) but also get added as members of info.message
+        // (completely unexpected), so we have to parseInfo() those out.
+        const errorAdditionalMembers = parseInfo(info.message);
+        // eslint-disable-next-line no-restricted-syntax
+        for (const property of Object.keys(errorAdditionalMembers)) {
+            event[property] = errorAdditionalMembers[property];
+        }
+
+        eventString = JSON.stringify(event, null, 2);
+    } else if (!_.isEmpty(parseInfo(info))) {
+        event = parseInfo(info);
+        eventString = JSON.stringify(event, null, 2);
+    } else {
+        eventString = '';
+    }
+
+    return util.format(
+        '%s %s %s %s %s',
+        info.timestamp,
+        info.level,
+        message,
+        (stack) ? `\n${stack}` : '',
+        eventString ? `\n${eventString}` : ''
+    );
+});
 
 const jsonFormat = printf((info) => {
     const logObject = {
@@ -54,6 +97,30 @@ const jsonFormat = printf((info) => {
         logObject.err = {
             name: info.name,
             stack: info.stack
+        };
+    }
+
+    if (info.message instanceof Error) {
+        // Unfortunately, in this case...
+        // ```
+        // const err = new Error('error message');
+        // err.code = 'SOME_CODE'
+        // logger.info(err, { a: 'a', b: 'b' })
+        // ```
+        // ...the configured logger members (such as timestamp, service, node_env, etc.)
+        // are members of info (expected) but also get added as members of info.message
+        // (completely unexpected), so we have to parseInfo() those out.
+        const errorAdditionalMembers = parseInfo(info.message);
+        // eslint-disable-next-line no-restricted-syntax
+        for (const property of Object.keys(errorAdditionalMembers)) {
+            logObject.meta.event[property] = errorAdditionalMembers[property];
+        }
+
+        logObject.msg = info.message.message;
+
+        logObject.err = {
+            name: info.message.name,
+            stack: info.message.stack
         };
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -177,10 +177,31 @@ function parseInfo(infoObj) {
     ]);
 }
 
+function initLogLevelGte(configuredLogLevel = 'info') {
+    // Like JSON.parse(), this function and has the ability to throw errors.
+    // Therefore calls to it must be wrapped in try/catch.
+    return function logLevelGte(checkLogLevel) {
+        const validLogLevels = Object.keys(winston.config.npm.levels);
+
+        // TODO: Improve checking via using some sort of typing instead??
+        if (validLogLevels.indexOf(checkLogLevel) === -1) {
+            // eslint-disable-next-line max-len
+            throw new Error(`logLevelGte(): 'checkLogLevel' is ${checkLogLevel}, but it must be one of the valid levels ('error', 'warn', 'info', 'verbose', 'debug', 'silly').`);
+        }
+
+        if (validLogLevels.indexOf(configuredLogLevel) >= validLogLevels.indexOf(checkLogLevel)) {
+            return true;
+        }
+
+        return false;
+    };
+}
+
 module.exports = {
     addMetaFormat,
     configuredFormatter,
     consoleFormat,
     jsonFormat,
-    parseInfo
+    parseInfo,
+    initLogLevelGte
 };

--- a/test/format.test.js
+++ b/test/format.test.js
@@ -4,7 +4,7 @@ import _ from 'lodash';
 import SpyTransport from '@chrisalderson/winston-spy'; // eslint-disable-line no-unused-vars
 import util from 'util';
 import winston from 'winston';
-import { configuredFormatter, parseInfo } from '../lib'; // eslint-disable-line import/named
+import { configuredFormatter, parseInfo } from '../src'; // eslint-disable-line import/named
 
 const { createLogger } = winston;
 

--- a/test/logLevelGte.test.js
+++ b/test/logLevelGte.test.js
@@ -1,0 +1,95 @@
+/* eslint-env jest */
+
+import { initLogLevelGte } from '../src'; // eslint-disable-line import/named
+
+const logLevelGte = initLogLevelGte();
+
+describe.only('#logLevelGte()', () => {
+    it('Throws error if called with invalid log level', () => {
+        expect(() => logLevelGte('not_a_real_log_level')).toThrow();
+    });
+
+    it('Works when initialized with initLogLevelGte("error")', () => {
+        // eslint-disable-next-line no-shadow
+        const logLevelGte = initLogLevelGte('error');
+        expect(logLevelGte('error')).toEqual(true);
+        expect(logLevelGte('warn')).toEqual(false);
+        expect(logLevelGte('info')).toEqual(false);
+        expect(logLevelGte('http')).toEqual(false);
+        expect(logLevelGte('verbose')).toEqual(false);
+        expect(logLevelGte('debug')).toEqual(false);
+        expect(logLevelGte('silly')).toEqual(false);
+    });
+
+    it('Works when initialized with initLogLevelGte("warn")', () => {
+        // eslint-disable-next-line no-shadow
+        const logLevelGte = initLogLevelGte('warn');
+        expect(logLevelGte('error')).toEqual(true);
+        expect(logLevelGte('warn')).toEqual(true);
+        expect(logLevelGte('info')).toEqual(false);
+        expect(logLevelGte('http')).toEqual(false);
+        expect(logLevelGte('verbose')).toEqual(false);
+        expect(logLevelGte('debug')).toEqual(false);
+        expect(logLevelGte('silly')).toEqual(false);
+    });
+
+    it('Works when initialized with initLogLevelGte("info")', () => {
+        // eslint-disable-next-line no-shadow
+        const logLevelGte = initLogLevelGte('info');
+        expect(logLevelGte('error')).toEqual(true);
+        expect(logLevelGte('warn')).toEqual(true);
+        expect(logLevelGte('info')).toEqual(true);
+        expect(logLevelGte('http')).toEqual(false);
+        expect(logLevelGte('verbose')).toEqual(false);
+        expect(logLevelGte('debug')).toEqual(false);
+        expect(logLevelGte('silly')).toEqual(false);
+    });
+
+    it('Works when initialized with initLogLevelGte("http")', () => {
+        // eslint-disable-next-line no-shadow
+        const logLevelGte = initLogLevelGte('http');
+        expect(logLevelGte('error')).toEqual(true);
+        expect(logLevelGte('warn')).toEqual(true);
+        expect(logLevelGte('info')).toEqual(true);
+        expect(logLevelGte('http')).toEqual(true);
+        expect(logLevelGte('verbose')).toEqual(false);
+        expect(logLevelGte('debug')).toEqual(false);
+        expect(logLevelGte('silly')).toEqual(false);
+    });
+
+    it('Works when initialized with initLogLevelGte("verbose")', () => {
+        // eslint-disable-next-line no-shadow
+        const logLevelGte = initLogLevelGte('verbose');
+        expect(logLevelGte('error')).toEqual(true);
+        expect(logLevelGte('warn')).toEqual(true);
+        expect(logLevelGte('info')).toEqual(true);
+        expect(logLevelGte('http')).toEqual(true);
+        expect(logLevelGte('verbose')).toEqual(true);
+        expect(logLevelGte('debug')).toEqual(false);
+        expect(logLevelGte('silly')).toEqual(false);
+    });
+
+    it('Works when initialized with initLogLevelGte("debug")', () => {
+        // eslint-disable-next-line no-shadow
+        const logLevelGte = initLogLevelGte('debug');
+        expect(logLevelGte('error')).toEqual(true);
+        expect(logLevelGte('warn')).toEqual(true);
+        expect(logLevelGte('info')).toEqual(true);
+        expect(logLevelGte('http')).toEqual(true);
+        expect(logLevelGte('verbose')).toEqual(true);
+        expect(logLevelGte('debug')).toEqual(true);
+        expect(logLevelGte('silly')).toEqual(false);
+    });
+
+    it('Works when initialized with initLogLevelGte("silly")', () => {
+        // eslint-disable-next-line no-shadow
+        const logLevelGte = initLogLevelGte('silly');
+        expect(logLevelGte('error')).toEqual(true);
+        expect(logLevelGte('warn')).toEqual(true);
+        expect(logLevelGte('info')).toEqual(true);
+        expect(logLevelGte('http')).toEqual(true);
+        expect(logLevelGte('verbose')).toEqual(true);
+        expect(logLevelGte('debug')).toEqual(true);
+        expect(logLevelGte('silly')).toEqual(true);
+    });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -751,11 +751,18 @@ async-limiter@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.0.tgz#78faed8c3d074ab81f22b4e985d79e8738f720f8"
 
-async@^2.1.4, async@^2.5.0, async@^2.6.0:
+async@^2.1.4, async@^2.5.0:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/async/-/async-2.6.1.tgz#b245a23ca71930044ec53fa46aa00a3e87c6a610"
   dependencies:
     lodash "^4.17.10"
+
+async@^2.6.1:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/async/-/async-2.6.2.tgz#18330ea7e6e313887f5d2f2a904bac6fe4dd5381"
+  integrity sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==
+  dependencies:
+    lodash "^4.17.11"
 
 asynckit@^0.4.0:
   version "0.4.0"
@@ -2089,7 +2096,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@^2.0.1, inherits@~2.0.3:
+inherits@2, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
 
@@ -2916,15 +2923,16 @@ lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4, lodash@^4.17.5
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
 
-logform@^1.9.1:
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/logform/-/logform-1.10.0.tgz#c9d5598714c92b546e23f4e78147c40f1e02012e"
+logform@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/logform/-/logform-2.1.2.tgz#957155ebeb67a13164069825ce67ddb5bb2dd360"
+  integrity sha512-+lZh4OpERDBLqjiwDLpAWNQu6KMjnlXH2ByZwCuSqVPJletw0kTWJf5CgSNAUKn1KUkv3m2cUz/LK8zyEy7wzQ==
   dependencies:
     colors "^1.2.1"
     fast-safe-stringify "^2.0.4"
     fecha "^2.3.3"
     ms "^2.1.1"
-    triple-beam "^1.2.0"
+    triple-beam "^1.3.0"
 
 lolex@^2.3.2:
   version "2.7.5"
@@ -3630,6 +3638,15 @@ readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.6, readable
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
+readable-stream@^3.1.1:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.3.0.tgz#cb8011aad002eb717bf040291feba8569c986fb9"
+  integrity sha512-EsI+s3k3XsW+fU8fQACLN59ky34AZ14LoeVZpYwmZvldCFo0r0gnelwF2TcMjLor/BTL5aDJVBMkss0dthToPw==
+  dependencies:
+    inherits "^2.0.3"
+    string_decoder "^1.1.1"
+    util-deprecate "^1.0.1"
+
 readdirp@^2.0.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-2.2.1.tgz#0e87622a3325aa33e892285caf8b4e846529a525"
@@ -4105,6 +4122,13 @@ string-width@^1.0.1:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
 
+string_decoder@^1.1.1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.2.0.tgz#fe86e738b19544afe70469243b2a1ee9240eae8d"
+  integrity sha512-6YqyX6ZWEYguAxgZzHGL7SsCeGx3V2TtOTqZz1xSTSWnqsbWwbptafNyvf/ACquZUXV3DANr5BDIwNYe1mN42w==
+  dependencies:
+    safe-buffer "~5.1.0"
+
 string_decoder@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
@@ -4370,7 +4394,7 @@ use@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
 
-util-deprecate@~1.0.1:
+util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
 
@@ -4475,26 +4499,28 @@ winston-transport@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/winston-transport/-/winston-transport-3.2.1.tgz#5b79b294096b1a18bfe502e769491553a2cb1042"
 
-winston-transport@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/winston-transport/-/winston-transport-4.2.0.tgz#a20be89edf2ea2ca39ba25f3e50344d73e6520e5"
+winston-transport@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/winston-transport/-/winston-transport-4.3.0.tgz#df68c0c202482c448d9b47313c07304c2d7c2c66"
+  integrity sha512-B2wPuwUi3vhzn/51Uukcao4dIduEiPOcOt9HJ3QeaXgkJ5Z7UwpBzxS4ZGNHtrxrUvTwemsQiSys0ihOf8Mp1A==
   dependencies:
     readable-stream "^2.3.6"
     triple-beam "^1.2.0"
 
-winston@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/winston/-/winston-3.1.0.tgz#80724376aef164e024f316100d5b178d78ac5331"
+winston@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/winston/-/winston-3.2.1.tgz#63061377976c73584028be2490a1846055f77f07"
+  integrity sha512-zU6vgnS9dAWCEKg/QYigd6cgMVVNwyTzKs81XZtTFuRwJOcDdBg7AU0mXVyNbs7O5RH2zdv+BdNZUlx7mXPuOw==
   dependencies:
-    async "^2.6.0"
+    async "^2.6.1"
     diagnostics "^1.1.1"
     is-stream "^1.1.0"
-    logform "^1.9.1"
+    logform "^2.1.1"
     one-time "0.0.4"
-    readable-stream "^2.3.6"
+    readable-stream "^3.1.1"
     stack-trace "0.0.x"
     triple-beam "^1.3.0"
-    winston-transport "^4.2.0"
+    winston-transport "^4.3.0"
 
 wordwrap@~0.0.2:
   version "0.0.3"


### PR DESCRIPTION
### Jira Ticket(s)
[SER-281](https://jira.amida.com/browse/SER-281)

### To Test

#### Test 1

`yarn test`.

#### Test 2 (optional): 

Step A: Setup logging

In `format.test.js`, in each of the `beforeEach()` callbacks that specify a jest mock function (e.g. `spy = jest.fn()`), add this logging statement: `console.log(expectedMessage);`

Step B: Setup script

In `package.json`, add this script `"test-with-logging": "yarn install && jest --verbose=false",`

Step C: Run it

`yarn test-with-logging`

Results: Logged to your terminal should be each of the desired outcomes listed in the jira ticket.
